### PR TITLE
Payload (Event and Command) serialization

### DIFF
--- a/services/shared/payload/package.json
+++ b/services/shared/payload/package.json
@@ -7,9 +7,11 @@
   "private": true,
   "scripts": {
     "build": "./node_modules/.bin/tsc",
-    "test": "./node_modules/.bin/mocha -r ts-node/register test/**/*.ts"
+    "test": "./node_modules/.bin/mocha -r ts-node/register test/**/*.ts",
+    "test:watch": "./node_modules/.bin/mocha -r ts-node/register test/**/*.ts --watch --watch-extensions ts"
   },
   "dependencies": {
+    "typescript-json-serializer": "^1.4.2",
     "uuid": "^3.3.3"
   },
   "devDependencies": {

--- a/services/shared/payload/payload.ts
+++ b/services/shared/payload/payload.ts
@@ -1,4 +1,6 @@
 const uuidv1 = require('uuid/v4');
+import { JsonProperty, Serializable, deserialize, serialize } from 'typescript-json-serializer'
+
 
 interface RabbitPayload {
     version: number, // sequentual numebering system for payload API version
@@ -9,12 +11,24 @@ interface RabbitPayload {
     data: object
 }
 
+@Serializable()
 export class Event implements RabbitPayload  {
+    @JsonProperty()
     readonly version: number = 1 // sequentual numebering system
+
+    @JsonProperty()
     readonly id: string = uuidv1()
+
+    @JsonProperty()
     sender: string
+
+    @JsonProperty()
     readonly type: string = 'Event'
+
+    @JsonProperty()
     name: string
+
+    @JsonProperty()
     data: object
 
     /**
@@ -27,14 +41,65 @@ export class Event implements RabbitPayload  {
         this.name = name
         this.data = data
     }
+
+    /**
+     * Serialize an Event to a common JSON object
+     *
+     * @returns Object
+     */
+    toJSON(): Object {
+        return Object(serialize(this))
+    }
+
+    /**
+     * Deserialize a JSON Object to an Event instance
+     * 
+     * @param json
+     * @returns Event
+     */
+    static fromJSON(json: Object): Event {
+        return deserialize(json, Event)
+    }
+
+    /**
+     * Serialize an Event to a Buffer
+     * 
+     * @returns Buffer
+     */
+    toBuffer(): Buffer {
+        return Buffer.from(JSON.stringify(this.toJSON()))
+    }
+
+    /**
+     * Deserialize a Buffer to an Event instance
+     * 
+     * @param buffer
+     * @returns Event
+     */
+    static fromBuffer(buffer: Buffer): Event {
+        return deserialize(JSON.parse(buffer.toString()), Event)
+    }
 }
 
+
+@Serializable()
 export class Command implements RabbitPayload  {
+    @JsonProperty()
     readonly version: number = 1 // sequentual numebering system
+
+    @JsonProperty()
     readonly id: string = uuidv1()
+
+    @JsonProperty()
     sender: string
+    
+    @JsonProperty()
     readonly type: string = 'Command'
+    
+    @JsonProperty()
     name: string
+    
+    @JsonProperty()
     data: object
 
     /**
@@ -46,5 +111,43 @@ export class Command implements RabbitPayload  {
         this.sender = sender
         this.name = name
         this.data = data
+    }
+
+    /**
+     * Serialize a Command to a common JSON object
+     *
+     * @returns Object
+     */
+    toJSON(): Object {
+        return Object(serialize(this))
+    }
+
+    /**
+     * Deserialize a JSON Object to a Command instance
+     * 
+     * @param json
+     * @returns Command
+     */
+    static fromJSON(json: Object): Command {
+        return deserialize(json, Command)
+    }
+
+    /**
+     * Serialize a Command to a Buffer
+     * 
+     * @returns Buffer
+     */
+    toBuffer(): Buffer {
+        return Buffer.from(JSON.stringify(this.toJSON()))
+    }
+
+    /**
+     * Deserialize a Buffer to a Command instance
+     * 
+     * @param buffer
+     * @returns Command
+     */
+    static fromBuffer(buffer: Buffer): Command {
+        return deserialize(JSON.parse(buffer.toString()), Command)
     }
 }

--- a/services/shared/payload/test/command-test.ts
+++ b/services/shared/payload/test/command-test.ts
@@ -12,4 +12,24 @@ describe('Command Test', () => {
         assert.equal(testCommand.name, 'MyCommand')
         assert.deepEqual(testCommand.data, jsonPayload)
     })
+
+    it('should serialize Event to JSON', () => {
+        const jsonPayload = { 'hello': 'world' }
+        const testCommand = new Command('MyService', 'MyEvent', jsonPayload)
+
+        const json = testCommand.toJSON()
+        const serializedTestEvent = Command.fromJSON(json)
+
+        assert.deepEqual(testCommand, serializedTestEvent)
+    })
+
+    it('should serialize Event to Buffer', () => {
+        const jsonPayload = { 'hello': 'world' }
+        const testEvent = new Command('MyService', 'MyEvent', jsonPayload)
+
+        const json = testEvent.toBuffer()
+        const serializedTestEvent = Command.fromBuffer(json)
+
+        assert.deepEqual(testEvent, serializedTestEvent)
+    })
 })

--- a/services/shared/payload/test/command-test.ts
+++ b/services/shared/payload/test/command-test.ts
@@ -1,0 +1,15 @@
+import { assert } from 'chai'
+import { Command } from '../payload'
+import { describe, it } from 'mocha'
+
+
+describe('Command Test', () => {
+    it('should be well tested', () => {
+        const jsonPayload = { 'hello': 'world' }
+        const testCommand = new Command('MyService', 'MyCommand', jsonPayload)
+        
+        assert.equal(testCommand.sender, 'MyService')
+        assert.equal(testCommand.name, 'MyCommand')
+        assert.deepEqual(testCommand.data, jsonPayload)
+    })
+})

--- a/services/shared/payload/test/event-test.ts
+++ b/services/shared/payload/test/event-test.ts
@@ -1,17 +1,7 @@
 import { assert } from 'chai'
-import { Command, Event } from '../payload'
+import { Event } from '../payload'
 import { describe, it } from 'mocha'
 
-describe('Command Test', () => {
-    it('should be well tested', () => {
-        const jsonPayload = { 'hello': 'world' }
-        const testCommand = new Command('MyService', 'MyCommand', jsonPayload)
-        
-        assert.equal(testCommand.sender, 'MyService')
-        assert.equal(testCommand.name, 'MyCommand')
-        assert.deepEqual(testCommand.data, jsonPayload)
-    })
-})
 
 describe('Event Test', () => {
     it('should be well tested', () => {

--- a/services/shared/payload/test/event-test.ts
+++ b/services/shared/payload/test/event-test.ts
@@ -6,10 +6,30 @@ import { describe, it } from 'mocha'
 describe('Event Test', () => {
     it('should be well tested', () => {
         const jsonPayload = { 'hello': 'world' }
-        const testCommand = new Event('MyService', 'MyEvent', jsonPayload)
+        const testEvent = new Event('MyService', 'MyEvent', jsonPayload)
         
-        assert.equal(testCommand.sender, 'MyService')
-        assert.equal(testCommand.name, 'MyEvent')
-        assert.deepEqual(testCommand.data, jsonPayload)
+        assert.equal(testEvent.sender, 'MyService')
+        assert.equal(testEvent.name, 'MyEvent')
+        assert.deepEqual(testEvent.data, jsonPayload)
+    })
+
+    it('should serialize Event to JSON', () => {
+        const jsonPayload = { 'hello': 'world' }
+        const testEvent = new Event('MyService', 'MyEvent', jsonPayload)
+
+        const json = testEvent.toJSON()
+        const serializedTestEvent = Event.fromJSON(json)
+
+        assert.deepEqual(testEvent, serializedTestEvent)
+    })
+
+    it('should serialize Event to Buffer', () => {
+        const jsonPayload = { 'hello': 'world' }
+        const testEvent = new Event('MyService', 'MyEvent', jsonPayload)
+
+        const json = testEvent.toBuffer()
+        const serializedTestEvent = Event.fromBuffer(json)
+
+        assert.deepEqual(testEvent, serializedTestEvent)
     })
 })

--- a/services/shared/payload/tsconfig.json
+++ b/services/shared/payload/tsconfig.json
@@ -4,7 +4,9 @@
         "target": "ES2019",
         "outDir": "dist",
         "declaration": true,
-        "strict": true
+        "strict": true,
+        "emitDecoratorMetadata": true,
+        "experimentalDecorators": true
     },
     "exclude": [
         "test/",

--- a/services/shared/payload/yarn.lock
+++ b/services/shared/payload/yarn.lock
@@ -501,6 +501,11 @@ pathval@^1.1.0:
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
   integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
 
+reflect-metadata@^0.1.13:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
+  integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -620,6 +625,13 @@ type-detect@^4.0.0, type-detect@^4.0.5:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+
+typescript-json-serializer@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/typescript-json-serializer/-/typescript-json-serializer-1.4.2.tgz#b807810640e95ca4944b69f89c1e7662952a69d5"
+  integrity sha512-3SGIqkrDNwDFuTlDkc/HvsJj2KAxTCdb81D6rhVCwv7KS3z9UZgrKmhHCd1w3X4CVkAtwKnzi6PSIY0SPPzoVw==
+  dependencies:
+    reflect-metadata "^0.1.13"
 
 typescript@^3.7.3:
   version "3.7.3"


### PR DESCRIPTION
Add simple methods for serializing and deserializing Events and Commands.

Includes methods to serialize and deserialize to/from JSON or to/from a Buffer (some RabbitMQ clients will let you pass a buffer as a message, so this method could be useful. if not, we can delete later.).

Using as a test before moving on to serializing the `Machine` and `Network` classes in #3, which will be more involved.